### PR TITLE
Add harp as dev-dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
   "bugs": {
     "url": "https://github.com/josex2r/60fps-workshop/issues"
   },
-  "homepage": "https://github.com/josex2r/60fps-workshop#readme"
+  "homepage": "https://github.com/josex2r/60fps-workshop#readme",
+  "devDependencies": {
+    "harp": "^0.24.0"
+  }
 }


### PR DESCRIPTION
This change will make `node run server` work without needing to have harp installed globally.